### PR TITLE
Patch now_is_between

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ def test_click_light_turn_on_for_5_minutes(given_that, living_room, assert_that)
     time_travel.fast_forward(1).minutes()    
     time_travel.assert_current_time(5).minutes()
     assert_that('light.bathroom').was.turned_off()
+    
 ```
 
 ---
@@ -80,6 +81,14 @@ Let's test an Appdaemon automation we created, which, say, handles automatic lig
        given_that.state_of('sensor.living_room_illumination').is_set_to(200) # 200lm == night
        living_room._new_motion(None, None, None)
        assert_that('light.living_room').was.turned_on()
+       
+       # Change entity states 
+       given_that.state_of('device_tracker.person).is_set_to('away')
+       given_that.mock_functions_are_cleared()
+       
+       living_room._new_motion(None, None, None)
+       assert_that('light.living_room').was_not.turned_on()
+       
    ```
    > ##### Note
    > The following fixtures are **injected** by pytest using the **[`conftest.py`](https://github.com/FlorianKempenich/Appdaemon-Test-Framework/blob/master/conftest.py) file** and the **initialisation fixture created at Step 1**:
@@ -296,7 +305,7 @@ This test framework abstracts away all that complexity, allowing for a smooth TD
 
 **Couldn't we just use the MVP pattern with clear interfaces at the boundaries?**  
 _Yes we could... but would we?  
-Let's be pragmatic, with that kind of project we're developing for our home, and we're a team of one.
+Let's be pragmatic, with what kind of project we're developing for our home, and we're a team of one.
 While being a huge proponent for [clean architecture](https://floriankempenich.com/post/11), I believe using such a complex architecture for such a simple project would only result in bringing more complexity than necessary._
 
 ### Enjoy the simplicity

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ This test framework abstracts away all that complexity, allowing for a smooth TD
 
 **Couldn't we just use the MVP pattern with clear interfaces at the boundaries?**  
 _Yes we could... but would we?  
-Let's be pragmatic, with what kind of project we're developing for our home, and we're a team of one.
+Let's be pragmatic, with this kind of project we're developing for our home, and we're a team of one.
 While being a huge proponent for [clean architecture](https://floriankempenich.com/post/11), I believe using such a complex architecture for such a simple project would only result in bringing more complexity than necessary._
 
 ### Enjoy the simplicity

--- a/README.md
+++ b/README.md
@@ -80,15 +80,7 @@ Let's test an Appdaemon automation we created, which, say, handles automatic lig
    def test_during_night_light_turn_on(given_that, living_room, assert_that):
        given_that.state_of('sensor.living_room_illumination').is_set_to(200) # 200lm == night
        living_room._new_motion(None, None, None)
-       assert_that('light.living_room').was.turned_on()
-       
-       # Change entity states 
-       given_that.state_of('device_tracker.person).is_set_to('away')
-       given_that.mock_functions_are_cleared()
-       
-       living_room._new_motion(None, None, None)
-       assert_that('light.living_room').was_not.turned_on()
-       
+       assert_that('light.living_room').was.turned_on()      
    ```
    > ##### Note
    > The following fixtures are **injected** by pytest using the **[`conftest.py`](https://github.com/FlorianKempenich/Appdaemon-Test-Framework/blob/master/conftest.py) file** and the **initialisation fixture created at Step 1**:

--- a/appdaemontestframework/init_framework.py
+++ b/appdaemontestframework/init_framework.py
@@ -34,7 +34,8 @@ def patch_hass():
     patch_turn_off = mock.patch.object(Hass, 'turn_off')
     # Custom callback functions
     patch_register_constraint = mock.patch.object(Hass, 'register_constraint')
-
+    patch_now_is_between = mock.patch.object(Hass, 'now_is_between')
+    
     ## Initialize patches
     patched_run_daily = patch_run_daily.start()
     patched_run_in = patch_run_in.start()
@@ -48,7 +49,8 @@ def patch_hass():
     patched_turn_on = patch_turn_on.start()
     patched_turn_off = patch_turn_off.start()
     patched_register_constraint = patch_register_constraint.start()
-
+    patched_now_is_between = patch_now_is_between.start()
+    
     ## Setup un-patch callback
     def unpatch_callback():
         patch___init__.stop()
@@ -65,7 +67,8 @@ def patch_hass():
         patch_turn_off.stop()
         patch_turn_on.stop()
         patch_register_constraint.stop()
-
+        patch_now_is_between.stop()
+        
     return ({
         'run_daily': patched_run_daily,
         'run_in': patched_run_in,
@@ -78,5 +81,6 @@ def patch_hass():
         'call_service': patched_call_service,
         'turn_on': patched_turn_on,
         'turn_off': patched_turn_off,
-        'register_constraint': patched_register_constraint
+        'register_constraint': patched_register_constraint,
+        'now_is_between': patched_now_is_between
     }, unpatch_callback)


### PR DESCRIPTION
Python throws error when app uses this function.

```
apps/LightingSM.py:242: in on_enter_active
    if self.is_night():
apps/LightingSM.py:201: in is_night
    return self.now_is_between(self.night_mode['start_time'], self.night_mode['end_time'])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <apps.LightingSM.LightingSM object at 0x7f7530171eb8>, start_time_str = '20:00:00', end_time_str = '20:00:00', name = None

    def now_is_between(self, start_time_str, end_time_str, name=None):
>       return self.AD.now_is_between(start_time_str, end_time_str, name)
E       AttributeError: 'LightingSM' object has no attribute 'AD'

/usr/local/lib/python3.6/site-packages/appdaemon/appapi.py:300: AttributeError
```

Hopefully I can mock it, though getting the function itself to work would be better. Any idea why Python may not be able to find the `AD` object?

```
given_that.passed_arg('night_mode').is_set_to(night)
    given_that.time_is(time(hour=19))

    ml.initialize()
    given_that.mock_functions_are_cleared()

    ml.sensor_state_change(SENSOR_ENTITY, None, 'off', 'on', None)
    ml.sensor_state_change(SENSOR_ENTITY, None, 'on', 'off', None)
    

    assert_that(CONTROL_ENTITY).was.turned_on(brightness=100)
    assert ml.previous_delay == 180
    given_that.time_is(time(hour=20))
    given_that.mock_functions_are_cleared()
    

    ml.sensor_state_change(SENSOR_ENTITY, None, 'off', 'on', None)
```
The only strange thing I am doing (is it strange?) is setting new values using `given_that` and then calling `given_that.mock_functions_are_cleared()` again (without calling `initialize()`