### PR TITLE
[fix] get_state to match appdaemon's api

### DIFF
--- a/appdaemontestframework/given_that.py
+++ b/appdaemontestframework/given_that.py
@@ -25,13 +25,14 @@ class GivenThatWrapper:
     def _init_mocked_states(self):
         self.mocked_states = {}
 
-        def get_state_mock(entity_id, attribute=None):
+        def get_state_mock(entity_id, **kwargs):
             if entity_id not in self.mocked_states:
                 raise StateNotSetError(entity_id)
 
             state = self.mocked_states[entity_id]
 
-            if not attribute:
+            attribute = kwargs.get("attribute", None)
+            if attribute is None:
                 return state['main']
             elif attribute == 'all':
                 return state['attributes']

--- a/appdaemontestframework/given_that.py
+++ b/appdaemontestframework/given_that.py
@@ -25,13 +25,12 @@ class GivenThatWrapper:
     def _init_mocked_states(self):
         self.mocked_states = {}
 
-        def get_state_mock(entity_id, **kwargs):
+        def get_state_mock(entity_id, *, attribute=None):
             if entity_id not in self.mocked_states:
                 raise StateNotSetError(entity_id)
 
             state = self.mocked_states[entity_id]
 
-            attribute = kwargs.get("attribute", None)
             if attribute is None:
                 return state['main']
             elif attribute == 'all':

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -1,3 +1,4 @@
+import pytest
 from appdaemon.plugins.hass.hassapi import Hass
 from pytest import raises
 
@@ -19,6 +20,9 @@ class MockAutomation(Hass):
 
     def get_all_attributes_from_light(self):
         return self.get_state(LIGHT, attribute='all')
+
+    def get_without_using_keyword(self):
+        return self.get_state(LIGHT, 'brightness')
 
 
 @automation_fixture(MockAutomation)
@@ -55,3 +59,10 @@ def test_set_and_get_attribute(given_that, automation: MockAutomation):
 def test_set_and_get_all_attribute(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
     assert automation.get_all_attributes_from_light() == {'brightness': 11, 'color': 'blue'}
+
+
+@pytest.mark.only
+def test_throw_typeerror_when_attributes_arg_not_passed_via_keyword(given_that, automation: MockAutomation):
+    given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
+    with pytest.raises(TypeError):
+        automation.get_without_using_keyword()


### PR DESCRIPTION
There is currently a bug in the testing framework that causes attributes to be returned when they should throw a TypeError. Appdaemon's api only takes one positional argument and then catches all kwargs. The framework takes two positional arguments leading to a mismatch in APIs.

For example, this would throw a TypeError in appdaemon, but does not in the framework:
```
self.get_state(self.entity_id, "friendly_name")
```

This should actually be called as:
```
self.get_state(self.entity_id, attribute="friendly_name")
```