### PR TITLE
Add cancel timer to time_travel

### DIFF
--- a/appdaemontestframework/init_framework.py
+++ b/appdaemontestframework/init_framework.py
@@ -23,6 +23,7 @@ def patch_hass():
         'run_daily',
         'run_minutely',
         'run_in',
+        'cancel_timer',
         'listen_event',
         'listen_state',
 

--- a/appdaemontestframework/time_travel.py
+++ b/appdaemontestframework/time_travel.py
@@ -6,13 +6,13 @@ class TimeTravelWrapper:
     """
 
     def __init__(self, hass_functions):
-        self.scheduler_mock = SchedulerMocks()
+        self.scheduler_mocks = SchedulerMocks()
 
         run_in_magic_mock = hass_functions['run_in']
-        run_in_magic_mock.side_effect = self.scheduler_mock.run_in_mock
+        run_in_magic_mock.side_effect = self.scheduler_mocks.run_in_mock
 
         cancel_timer_magic_mock = hass_functions['cancel_timer']
-        cancel_timer_magic_mock.side_effect = self.scheduler_mock.cancel_timer_mock
+        cancel_timer_magic_mock.side_effect = self.scheduler_mocks.cancel_timer_mock
 
     def fast_forward(self, duration):
         """
@@ -46,10 +46,10 @@ class TimeTravelWrapper:
 
 
     def _fast_forward_seconds(self, seconds_to_fast_forward):
-        self.scheduler_mock.fast_forward(seconds_to_fast_forward)
+        self.scheduler_mocks.fast_forward(seconds_to_fast_forward)
 
     def _assert_current_time_seconds(self, expected_seconds_from_start):
-        assert self.scheduler_mock.now == expected_seconds_from_start
+        assert self.scheduler_mocks.now == expected_seconds_from_start
 
 
 class UnitsWrapper:

--- a/test/test_time_travel.py
+++ b/test/test_time_travel.py
@@ -1,0 +1,36 @@
+from appdaemon.plugins.hass.hassapi import Hass
+from appdaemontestframework import automation_fixture
+import mock
+
+
+class MockAutomation(Hass):
+    def initialize(self):
+        pass
+
+
+@automation_fixture(MockAutomation)
+def automation():
+    pass
+
+
+def test_callback_not_called_before_timeout(time_travel, automation):
+    foo = mock.Mock()
+    automation.run_in(foo, 10)
+    time_travel.fast_forward(5).seconds()
+    foo.assert_not_called()
+
+
+def test_callback_called_after_timeout(time_travel, automation):
+    foo = mock.Mock()
+    automation.run_in(foo, 10)
+    time_travel.fast_forward(20).seconds()
+    foo.assert_called()
+
+
+def test_canceled_timer_does_not_run_callback(time_travel, automation):
+    foo = mock.Mock()
+    handle = automation.run_in(foo, 10)
+    time_travel.fast_forward(5).seconds()
+    automation.cancel_timer(handle)
+    time_travel.fast_forward(10).seconds()
+    foo.assert_not_called()


### PR DESCRIPTION
This PR adds support to time_travel for the `cancel_timer` API in AppDaemon.

This works by extending the existing `RunInMock` to provide a `cancel_timer` mock as well.  It will keep track of timers with a UUID handle. If `cancel_timer` is called with a matching UUID, it will remove that timer before it is called.

This PR also fixes a bug in `RunInMock._run_callbacks()._run()` where it was creating a closure with the value `registration` when it looks like it wanted to use the argument `callback_registration`.

Finally this adds a few tests for `time_travel` including the new `cancel_timer` API.