### PR TITLE
Add mocks for more scheduler functions

### DIFF
--- a/appdaemontestframework/init_framework.py
+++ b/appdaemontestframework/init_framework.py
@@ -19,11 +19,21 @@ def patch_hass():
         'log',
         'error',
 
-        # Callback registrations functions
-        'run_daily',
-        'run_minutely',
+        # Scheduler callback registrations functions
         'run_in',
+        'run_once',
+        'run_at',
+        'run_daily',
+        'run_hourly',
+        'run_minutely',
+        'run_every',
         'cancel_timer',
+
+        # Sunrise and sunset functions
+        'run_at_sunrise',
+        'run_at_sunset',
+
+        # Listener callback registrations functions
         'listen_event',
         'listen_state',
 


### PR DESCRIPTION
This PR adds default mocks for more `Hass` scheduler functions.

I have automations that make use of these, so a default mock gets some tests running at least. This is in support of a larger PR I am working on to add more functionality to the `timer_travel` test fixture.

- Add sunrise/sunset schedulers
- Add various `run_*` functions
- re-order mocks to match AppDaemon documentation order