### PR TITLE
Support for new functions run_at, entity_exists, extented support for function get_state

### DIFF
--- a/appdaemontestframework/assert_that.py
+++ b/appdaemontestframework/assert_that.py
@@ -192,6 +192,8 @@ class RegisteredWrapper:
         self.automation_thing_to_check = automation_thing_to_check
         self._run_daily = hass_functions['run_daily']
         self._run_mintely = hass_functions['run_minutely']
+        self._run_at = hass_functions['run_at']
+
 
     def run_daily(self, time_, **kwargs):
         registered_wrapper = self
@@ -213,6 +215,19 @@ class RegisteredWrapper:
             def with_callback(self, callback):
                 registered_wrapper.automation_thing_to_check.initialize()
                 registered_wrapper._run_mintely.assert_any_call(
+                    callback,
+                    time_,
+                    **kwargs)
+
+        return WithCallbackWrapper()
+
+    def run_at(self, time_, **kwargs):
+        registered_wrapper = self
+
+        class WithCallbackWrapper:
+            def with_callback(self, callback):
+                registered_wrapper.automation_thing_to_check.initialize()
+                registered_wrapper._run_at.assert_any_call(
                     callback,
                     time_,
                     **kwargs)

--- a/appdaemontestframework/given_that.py
+++ b/appdaemontestframework/given_that.py
@@ -7,7 +7,7 @@ class StateNotSetError(AppdaemonTestFrameworkError):
     def __init__(self, entity_id):
         super().__init__(f"""
         State for entity: '{entity_id}' was never set!
-        Please make sure to set the state with `given_that.state_of({entity_id}).is_set_to(STATE)` 
+        Please make sure to set the state with `given_that.state_of({entity_id}).is_set_to(STATE)`
         before trying to access the mocked state
         """)
 
@@ -25,20 +25,35 @@ class GivenThatWrapper:
     def _init_mocked_states(self):
         self.mocked_states = {}
 
-        def get_state_mock(entity_id, *, attribute=None):
-            if entity_id not in self.mocked_states:
-                raise StateNotSetError(entity_id)
-
-            state = self.mocked_states[entity_id]
-
-            if attribute is None:
-                return state['main']
-            elif attribute == 'all':
-                return state['attributes']
+        def get_state_mock(entity_id=None, *, attribute=None):
+            if entity_id is None:
+                resdict = dict()
+                for entityid in self.mocked_states:
+                    state = self.mocked_states[entityid]
+                    resdict.update({entityid: {"state" : state['main'], "attributes" : state['attributes']}})
+                return resdict
             else:
-                return state['attributes'].get(attribute)
+                if entity_id not in self.mocked_states:
+                    raise StateNotSetError(entity_id)
+
+                state = self.mocked_states[entity_id]
+
+                if attribute is None:
+                    return state['main']
+                elif attribute == 'all':
+                    return state['attributes']
+                else:
+                    return state['attributes'].get(attribute)
 
         self.hass_functions['get_state'].side_effect = get_state_mock
+
+        def entity_exists_mock(entity_id):
+            if entity_id in self.mocked_states:
+                return True
+            else:
+                return False
+
+        self.hass_functions['entity_exists'].side_effect = entity_exists_mock
 
     def _init_mocked_passed_args(self):
         def make_magic_mock_behave_like_a_dict(magic_mock, dict_to_simulate):

--- a/appdaemontestframework/init_framework.py
+++ b/appdaemontestframework/init_framework.py
@@ -66,6 +66,9 @@ def patch_hass():
         MockInfo(Hass, 'register_constraint'),
         MockInfo(Hass, 'now_is_between'),
         MockInfo(Hass, 'notify'),
+
+        # Miscellaneous Helper Functions
+        MockInfo(Hass, 'entity_exists')
     ]
 
     patches = []

--- a/test/test_assert_callback_registration.py
+++ b/test/test_assert_callback_registration.py
@@ -1,4 +1,4 @@
-from datetime import time
+from datetime import time, datetime
 
 import appdaemon.plugins.hass.hassapi as hass
 import pytest
@@ -12,6 +12,7 @@ class MockAutomation(hass.Hass):
     should_listen_event = False
     should_register_run_daily = False
     should_register_run_minutely = False
+    should_register_run_at = False
 
     def initialize(self):
         if self.should_listen_state:
@@ -22,6 +23,8 @@ class MockAutomation(hass.Hass):
             self.run_daily(self._my_run_daily_callback, time(hour=3, minute=7), extra_param='ok')
         if self.should_register_run_minutely:
             self.run_minutely(self._my_run_minutely_callback, time(hour=3, minute=7), extra_param='ok')
+        if self.should_register_run_at:
+            self.run_at(self._my_run_at_callback, datetime(2019,11,5,22,43,0,0), extra_param='ok')
 
     def _my_listen_state_callback(self, entity, attribute, old, new, kwargs):
         pass
@@ -33,6 +36,9 @@ class MockAutomation(hass.Hass):
         pass
 
     def _my_run_minutely_callback(self, kwargs):
+        pass
+
+    def _my_run_at_callback(self, kwargs):
         pass
 
     def _some_other_function(self, entity, attribute, old, new, kwargs):
@@ -50,6 +56,8 @@ class MockAutomation(hass.Hass):
     def enable_register_run_minutely_during_initialize(self):
         self.should_register_run_minutely = True
 
+    def enable_register_run_at_during_initialize(self):
+        self.should_register_run_at = True
 
 @automation_fixture(MockAutomation)
 def automation():
@@ -229,4 +237,48 @@ class TestRegisteredRunMinutely:
         with pytest.raises(AssertionError):
             assert_that(automation) \
                 .registered.run_minutely(time(hour=3, minute=7), extra_param='ok') \
+                .with_callback(automation._some_other_function)
+
+
+class TestRegisteredRunAt:
+    def test_success(self, automation: MockAutomation, assert_that):
+        automation.enable_register_run_at_during_initialize()
+
+        assert_that(automation) \
+            .registered.run_at(datetime(2019,11,5,22,43,0,0), extra_param='ok') \
+            .with_callback(automation._my_run_at_callback)
+
+    def test_failure__not_listening(self, automation: MockAutomation, assert_that):
+        with pytest.raises(AssertionError):
+            assert_that(automation) \
+                .registered.run_at(datetime(2019,11,5,22,43,0,0), extra_param='ok') \
+                .with_callback(automation._my_run_at_callback)
+
+    def test_failure__wrong_time(self, automation: MockAutomation, assert_that):
+        automation.enable_register_run_at_during_initialize()
+
+        with pytest.raises(AssertionError):
+            assert_that(automation) \
+                .registered.run_at(datetime(2019,11,5,20,43,0,0), extra_param='ok') \
+                .with_callback(automation._my_run_at_callback)
+
+    def test_failure__wrong_kwargs(self, automation: MockAutomation, assert_that):
+        automation.enable_register_run_at_during_initialize()
+
+        with pytest.raises(AssertionError):
+            assert_that(automation) \
+                .registered.run_at(datetime(2019,11,5,22,43,0,0), extra_param='WRONG') \
+                .with_callback(automation._my_run_at_callback)
+
+        with pytest.raises(AssertionError):
+            assert_that(automation) \
+                .registered.run_at(datetime(2019,11,5,22,43,0,0), wrong='ok') \
+                .with_callback(automation._my_run_minutely_callback)
+
+    def test_failure__wrong_callback(self, automation: MockAutomation, assert_that):
+        automation.enable_register_run_at_during_initialize()
+
+        with pytest.raises(AssertionError):
+            assert_that(automation) \
+                .registered.run_at(datetime(2019,11,5,22,43,0,0), extra_param='ok') \
                 .with_callback(automation._some_other_function)

--- a/test/test_miscellaneous_helper_functions.py
+++ b/test/test_miscellaneous_helper_functions.py
@@ -1,0 +1,24 @@
+import appdaemon.plugins.hass.hassapi as hass
+
+from appdaemontestframework import automation_fixture
+
+COVER = 'cover.some_cover'
+
+class WithMiscellaneousHelperFunctions(hass.Hass):
+    def initialize(self):
+        pass
+
+    def get_entity_exists(self, entity):
+        return self.entity_exists(entity)
+
+@automation_fixture(WithMiscellaneousHelperFunctions)
+def with_miscellaneous_helper_functions():
+    pass
+
+
+def test_entity_exitsts_true(given_that, with_miscellaneous_helper_functions, hass_functions):
+    given_that.state_of(COVER).is_set_to("closed", {'friendly_name': f"{COVER}", 'current_position': 0})
+    assert with_miscellaneous_helper_functions.get_entity_exists(COVER)==True
+
+def test_entity_exitsts_false(given_that, with_miscellaneous_helper_functions, hass_functions):
+    assert with_miscellaneous_helper_functions.get_entity_exists("not_existent_entity")==False

--- a/test/test_miscellaneous_helper_functions.py
+++ b/test/test_miscellaneous_helper_functions.py
@@ -16,9 +16,9 @@ def with_miscellaneous_helper_functions():
     pass
 
 
-def test_entity_exitsts_true(given_that, with_miscellaneous_helper_functions, hass_functions):
+def test_entity_exists_true(given_that, with_miscellaneous_helper_functions, hass_functions):
     given_that.state_of(COVER).is_set_to("closed", {'friendly_name': f"{COVER}", 'current_position': 0})
     assert with_miscellaneous_helper_functions.get_entity_exists(COVER)==True
 
-def test_entity_exitsts_false(given_that, with_miscellaneous_helper_functions, hass_functions):
+def test_entity_exists_false(given_that, with_miscellaneous_helper_functions, hass_functions):
     assert with_miscellaneous_helper_functions.get_entity_exists("not_existent_entity")==False

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -6,6 +6,7 @@ from appdaemontestframework import automation_fixture
 from appdaemontestframework.given_that import StateNotSetError
 
 LIGHT = 'light.some_light'
+COVER = 'cover.some_cover'
 
 
 class MockAutomation(Hass):
@@ -23,6 +24,9 @@ class MockAutomation(Hass):
 
     def get_without_using_keyword(self):
         return self.get_state(LIGHT, 'brightness')
+
+    def get_complete_state_dictionary(self):
+        return self.get_state()
 
 
 @automation_fixture(MockAutomation)
@@ -60,9 +64,18 @@ def test_set_and_get_all_attribute(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
     assert automation.get_all_attributes_from_light() == {'brightness': 11, 'color': 'blue'}
 
+def test_get_complete_state_dictionary(given_that, automation: MockAutomation):
+    given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
+    given_that.state_of(COVER).is_set_to("closed", {'friendly_name': f"{COVER}", 'current_position': 0})
+    assert automation.get_complete_state_dictionary() == {COVER: {'attributes': {'current_position': 0,
+                                                                                                'friendly_name': COVER},
+                                                                                'state': 'closed'},
+                                                          LIGHT: {'attributes': {'brightness': 11, 'color': 'blue'},
+                                                                                'state': 'on'}}
 
 @pytest.mark.only
 def test_throw_typeerror_when_attributes_arg_not_passed_via_keyword(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
+    given_that.state_of(COVER).is_set_to('closed', attributes={'brightness': 11, 'color': 'blue'})
     with pytest.raises(TypeError):
         automation.get_without_using_keyword()

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -76,6 +76,5 @@ def test_get_complete_state_dictionary(given_that, automation: MockAutomation):
 @pytest.mark.only
 def test_throw_typeerror_when_attributes_arg_not_passed_via_keyword(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
-    given_that.state_of(COVER).is_set_to('closed', attributes={'brightness': 11, 'color': 'blue'})
     with pytest.raises(TypeError):
         automation.get_without_using_keyword()


### PR DESCRIPTION
Hi,

first of all thanks for this great project. It helped me a lot. For my project https://github.com/foxcris/appdaemon-blinds-control some functionality was missing so i added the required functionality. 

Here what i have done:
- added support for function run_at
- added support for function entity_exists
- added support for calling get_state without using any entity_id 
(request states for all enities)
- added testcases for all changes

I hope i meet all the requirements for a contribution. If you have questions or if something is missing or should be reworked please let me know. 