### PR TITLE
Support for kwargs in assert_that.was.turned_off()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "/Users/floriankempenich/.local/share/virtualenvs/appdaemontestframework_snjoetw-KTmiJq93/bin/python"
+}

--- a/README.md
+++ b/README.md
@@ -219,14 +219,15 @@ class LivingRoom(hass.Hass):
      ```python
      # Available commmands
      assert_that(ENTITY_ID).was.turned_on(OPTIONAL_KWARGS)
-     assert_that(ENTITY_ID).was.turned_off()
+     assert_that(ENTITY_ID).was.turned_off(OPTIONAL_KWARGS)
      assert_that(ENTITY_ID).was_not.turned_on(OPTIONAL_KWARGS)
-     assert_that(ENTITY_ID).was_not.turned_off()
+     assert_that(ENTITY_ID).was_not.turned_off(OPTIONAL_KWARGS)
 
      # Examples
      assert_that('light.living_room').was.turned_on()
      assert_that('light.living_room').was.turned_on(color_name=SHOWER_COLOR)
      assert_that('light.living_room').was_not.turned_off()
+     assert_that('light.living_room').was_not.turned_off(transition=2)
      ```
 
 *    #### Services

--- a/appdaemontestframework/assert_that.py
+++ b/appdaemontestframework/assert_that.py
@@ -84,7 +84,7 @@ class WasWrapper(Was):
         service_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['call_service'].assert_any_call(
                 ServiceOnAnyDomain('turn_on'),
-                {'entity_id': entity_id, **service_specific_parameters}))
+                **{'entity_id': entity_id, **service_specific_parameters}))
 
         turn_on_helper_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['turn_on'].assert_any_call(
@@ -102,7 +102,7 @@ class WasWrapper(Was):
         service_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['call_service'].assert_any_call(
                 ServiceOnAnyDomain('turn_off'),
-                {'entity_id': entity_id, **service_specific_parameters}))
+                **{'entity_id': entity_id, **service_specific_parameters}))
 
         turn_off_helper_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['turn_off'].assert_any_call(

--- a/appdaemontestframework/assert_that.py
+++ b/appdaemontestframework/assert_that.py
@@ -95,18 +95,19 @@ class WasWrapper(Was):
             raise EitherOrAssertionError(
                 service_not_called, turn_on_helper_not_called)
 
-    def turned_off(self):
+    def turned_off(self, **service_specific_parameters):
         """ Assert that a given entity_id has been turned off """
         entity_id = self.thing_to_check
 
         service_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['call_service'].assert_any_call(
                 ServiceOnAnyDomain('turn_off'),
-                entity_id=entity_id))
+                {'entity_id': entity_id, **service_specific_parameters}))
 
         turn_off_helper_not_called = _capture_assert_failure_exception(
             lambda: self.hass_functions['turn_off'].assert_any_call(
-                entity_id))
+                entity_id,
+                **service_specific_parameters))
 
         if service_not_called and turn_off_helper_not_called:
             raise EitherOrAssertionError(
@@ -134,10 +135,10 @@ class WasNotWrapper(Was):
                 "Should NOT have been turned ON w/ the given params: "
                 + str(self.was_wrapper.thing_to_check))
 
-    def turned_off(self):
+    def turned_off(self, **service_specific_parameters):
         """ Assert that a given entity_id has NOT been turned OFF """
         thing_not_turned_off = _capture_assert_failure_exception(
-            lambda: self.was_wrapper.turned_off())
+            lambda: self.was_wrapper.turned_off(**service_specific_parameters))
 
         if not thing_not_turned_off:
             raise AssertionError(

--- a/test/test_assert_that.py
+++ b/test/test_assert_that.py
@@ -1,0 +1,143 @@
+from datetime import time, datetime
+
+import appdaemon.plugins.hass.hassapi as hass
+import pytest
+from pytest import mark
+
+from appdaemontestframework import automation_fixture
+
+
+"""
+Note:
+The Appdaemon test framework was the fruit of a refactor of the tests
+suite of one of the Appdaemon projects I was working on at the time.
+Because it didn't start as a standalone project itself but was part of a test
+suite, it didn't have tests itself.
+(lessons learned, now my 'heavy' tests helpers are themselves tested :)
+
+Anyways, what that means is: Most of the base functionality is tested only
+through `integration_tests`.
+New feature should come with the proper unit tests.
+"""
+
+LIGHT = 'light.some_light'
+SWITCH = 'switch.some_switch'
+TRANSITION_DURATION = 2
+
+
+class MockAutomation(hass.Hass):
+    def initialize(self):
+        pass
+
+    def turn_on_light(self, via_helper=False):
+        if via_helper:
+            self.turn_on(LIGHT)
+        else:
+            self.call_service('light/turn_on', entity_id=LIGHT)
+
+    def turn_off_light(self, via_helper=False):
+        if via_helper:
+            self.turn_off(LIGHT)
+        else:
+            self.call_service('light/turn_off', entity_id=LIGHT)
+
+    def turn_on_switch(self, via_helper=False):
+        if via_helper:
+            self.turn_on(SWITCH)
+        else:
+            self.call_service('switch/turn_on', entity_id=SWITCH)
+
+    def turn_off_switch(self, via_helper=False):
+        if via_helper:
+            self.turn_off(SWITCH)
+        else:
+            self.call_service('switch/turn_off', entity_id=SWITCH)
+
+    def turn_on_light_with_transition(self, via_helper=False):
+        if via_helper:
+            self.turn_on(LIGHT, transition=TRANSITION_DURATION)
+        else:
+            self.call_service(
+                'light/turn_on',
+                entity_id=LIGHT,
+                transition=TRANSITION_DURATION
+            )
+
+    def turn_off_light_with_transition(self, via_helper=False):
+        if via_helper:
+            self.turn_off(LIGHT, transition=TRANSITION_DURATION)
+        else:
+            self.call_service(
+                'light/turn_off',
+                entity_id=LIGHT,
+                transition=TRANSITION_DURATION
+            )
+
+
+@automation_fixture(MockAutomation)
+def automation():
+    pass
+
+
+class TestTurnedOn:
+    class TestViaService:
+        def test_was_turned_on(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_on()
+            automation.turn_on_light()
+            assert_that(LIGHT).was.turned_on()
+
+            assert_that(SWITCH).was_not.turned_on()
+            automation.turn_on_switch()
+            assert_that(SWITCH).was.turned_on()
+
+        def test_with_kwargs(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_on()
+            automation.turn_on_light_with_transition()
+            assert_that(LIGHT).was.turned_on(transition=TRANSITION_DURATION)
+
+    class TestViaHelper:
+        def test_was_turned_on(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_on()
+            automation.turn_on_light(via_helper=True)
+            assert_that(LIGHT).was.turned_on()
+
+            assert_that(SWITCH).was_not.turned_on()
+            automation.turn_on_switch(via_helper=True)
+            assert_that(SWITCH).was.turned_on()
+
+        def test_with_kwargs(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_on()
+            automation.turn_on_light_with_transition(via_helper=True)
+            assert_that(LIGHT).was.turned_on(transition=TRANSITION_DURATION)
+
+
+class TestTurnedOff:
+    class TestViaService:
+        def test_was_turned_off(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_off()
+            automation.turn_off_light()
+            assert_that(LIGHT).was.turned_off()
+
+            assert_that(SWITCH).was_not.turned_off()
+            automation.turn_off_switch()
+            assert_that(SWITCH).was.turned_off()
+
+        def test_with_kwargs(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_off()
+            automation.turn_off_light_with_transition()
+            assert_that(LIGHT).was.turned_off(transition=TRANSITION_DURATION)
+
+    class TestViaHelper:
+        def test_was_turned_off(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_off()
+            automation.turn_off_light(via_helper=True)
+            assert_that(LIGHT).was.turned_off()
+
+            assert_that(SWITCH).was_not.turned_off()
+            automation.turn_off_switch(via_helper=True)
+            assert_that(SWITCH).was.turned_off()
+
+        def test_with_kwargs(self, assert_that, automation):
+            assert_that(LIGHT).was_not.turned_off()
+            automation.turn_off_light_with_transition(via_helper=True)
+            assert_that(LIGHT).was.turned_off(transition=TRANSITION_DURATION)


### PR DESCRIPTION
I have `self.turn_off(entity_id, transition=2)` in my automation and the existing `assert_that(entity_id).was.turned_off()` doesn't work.

The change in this PR is to address that.