### PR TITLE
[fix] "all" attribute argument in get_state

### DIFF
--- a/appdaemontestframework/given_that.py
+++ b/appdaemontestframework/given_that.py
@@ -41,7 +41,13 @@ class GivenThatWrapper:
                 if attribute is None:
                     return state['main']
                 elif attribute == 'all':
-                    return state['attributes']
+                    last_updated = state["attributes"].pop("last_updated", None)
+                    last_changed = state["attributes"].pop("last_changed", None)
+                    return {
+                        "last_updated": last_updated, "last_changed": last_changed,
+                        "state": state["main"], "attributes": state['attributes'],
+                        "entity_id": entity_id,
+                    }
                 else:
                     return state['attributes'].get(attribute)
 

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from appdaemon.plugins.hass.hassapi import Hass
 from pytest import raises
@@ -62,7 +64,18 @@ def test_set_and_get_attribute(given_that, automation: MockAutomation):
 
 def test_set_and_get_all_attribute(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})
-    assert automation.get_all_attributes_from_light() == {'brightness': 11, 'color': 'blue'}
+    assert automation.get_all_attributes_from_light() == {
+        'state': 'on', 'last_updated': None, 'last_changed': None, 'entity_id': LIGHT,
+        'attributes': {'brightness': 11, 'color': 'blue'}
+        }
+
+def test_set_and_get_all_attribute_last_updated_changed(given_that, automation: MockAutomation):
+    dt = datetime.datetime(year=2000, month=1, day=1).isoformat()
+    given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue', 'last_updated': dt, 'last_changed': dt})
+    assert automation.get_all_attributes_from_light() == {
+        'state': 'on', 'last_updated': dt, 'last_changed': dt, 'entity_id': LIGHT,
+        'attributes': {'brightness': 11, 'color': 'blue'}
+        }
 
 def test_get_complete_state_dictionary(given_that, automation: MockAutomation):
     given_that.state_of(LIGHT).is_set_to('on', attributes={'brightness': 11, 'color': 'blue'})


### PR DESCRIPTION
Currently, the passing "all" to get_state in order to get all attributes does not return a dict like is returned with Appdaemon. This PR fixes that and also adds in the last_updated and last_changed attributes that are included by default.

I've been running with this in production for several months and it's been working for me.