### PR TITLE
Add warning on appdeamon 3.x

### DIFF
--- a/appdaemontestframework/automation_fixture.py
+++ b/appdaemontestframework/automation_fixture.py
@@ -6,24 +6,20 @@ import pytest
 from appdaemon.plugins.hass.hassapi import Hass
 
 from appdaemontestframework.common import AppdaemonTestFrameworkError
-
-APPDAEMON_VERSION = pkg_resources.get_distribution('appdaemon').version
+from appdaemontestframework.hass_mocks import is_appdaemon_version_at_least
 
 
 class AutomationFixtureError(AppdaemonTestFrameworkError):
     pass
 
-def is_using_appdaemon_version_3_or_below():
-    return APPDAEMON_VERSION <= '4.0.0'
 
 def _instantiate_and_initialize_automation(function, automation_class, given_that, hass_functions, hass_mocks):
     _inject_helpers_and_call_function(function, given_that, hass_functions, hass_mocks)
 
-    if is_using_appdaemon_version_3_or_below():
+    if is_appdaemon_version_at_least('4.0.0'):
         automation = automation_class(
                 None,
                 automation_class.__name__,
-                None,
                 None,
                 None,
                 None,
@@ -34,6 +30,7 @@ def _instantiate_and_initialize_automation(function, automation_class, given_tha
         automation = automation_class(
                 None,
                 automation_class.__name__,
+                None,
                 None,
                 None,
                 None,

--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -13,9 +13,9 @@ class _DeprecatedAppdaemonWarning:
     min_supported_version = version.Version('4.0.0')
 
     def __init__(self):
-        if self.already_warned_deprecated_appdaemon_version:
+        if _DeprecatedAppdaemonWarning.already_warned_deprecated_appdaemon_version:
             return
-        self.already_warned_deprecated_appdaemon_version = True
+        _DeprecatedAppdaemonWarning.already_warned_deprecated_appdaemon_version = True
 
         appdaemon_version = version.Version(appdaemon.utils.__version__)
         if appdaemon_version < self.min_supported_version :

--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -1,16 +1,22 @@
 import logging
+import warnings
+
+import appdaemon.utils
 import mock
 from appdaemon.plugins.hass.hassapi import Hass
-import appdaemon.utils
-from packaging import version
-import textwrap
-import warnings
+from packaging.version import Version
+
+CURRENT_APPDAEMON_VERSION = Version(appdaemon.utils.__version__)
+
+
+def is_appdaemon_version_at_least(version_as_string):
+    expected_appdaemon_version = Version(version_as_string)
+    return CURRENT_APPDAEMON_VERSION >= expected_appdaemon_version
 
 
 class _DeprecatedAppdaemonVersionWarning:
     already_warned_during_this_test_session = False
-    min_supported_appdaemon_version = version.Version('4.0.0')
-    appdaemon_version = version.Version(appdaemon.utils.__version__)
+    min_supported_appdaemon_version = '4.0.0'
 
     @classmethod
     def show_warning_only_once(cls):
@@ -18,13 +24,16 @@ class _DeprecatedAppdaemonVersionWarning:
             return
         cls.already_warned_during_this_test_session = True
 
-        if cls.appdaemon_version < cls.min_supported_appdaemon_version:
+        appdaemon_version_supported = is_appdaemon_version_at_least(
+                cls.min_supported_appdaemon_version
+        )
+        if not appdaemon_version_supported:
             warnings.warn(
                     "Appdaemon-Test-Framework will only support Appdaemon >={} "
                     "in the next major release. "
                     "Your current Appdemon version is {}".format(
                             cls.min_supported_appdaemon_version,
-                            cls.appdaemon_version
+                            CURRENT_APPDAEMON_VERSION
                     ),
                     DeprecationWarning)
 

--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -7,25 +7,31 @@ import textwrap
 import warnings
 
 
-class _DeprecatedAppdaemonWarning:
-    # Use class vars so we can keep sticky state to only warn once per test session
-    already_warned_deprecated_appdaemon_version = False
-    min_supported_version = version.Version('4.0.0')
+class _DeprecatedAppdaemonVersionWarning:
+    already_warned_during_this_test_session = False
+    min_supported_appdaemon_version = version.Version('4.0.0')
+    appdaemon_version = version.Version(appdaemon.utils.__version__)
 
-    def __init__(self):
-        if _DeprecatedAppdaemonWarning.already_warned_deprecated_appdaemon_version:
+    @classmethod
+    def show_warning_only_once(cls):
+        if cls.already_warned_during_this_test_session is True:
             return
-        _DeprecatedAppdaemonWarning.already_warned_deprecated_appdaemon_version = True
+        cls.already_warned_during_this_test_session = True
 
-        appdaemon_version = version.Version(appdaemon.utils.__version__)
-        if appdaemon_version < self.min_supported_version :
-            warnings.warn("Appdaemon-Test-Framework will only support Appdaemon >={} in the next major release. Your current Appdemon version is {}"
-                            .format(self.min_supported_version, appdaemon_version), DeprecationWarning)
+        if cls.appdaemon_version < cls.min_supported_appdaemon_version:
+            warnings.warn(
+                    "Appdaemon-Test-Framework will only support Appdaemon >={} "
+                    "in the next major release. "
+                    "Your current Appdemon version is {}".format(
+                            cls.min_supported_appdaemon_version,
+                            cls.appdaemon_version
+                    ),
+                    DeprecationWarning)
 
 
 class HassMocks:
     def __init__(self):
-        _DeprecatedAppdaemonWarning()
+        _DeprecatedAppdaemonVersionWarning.show_warning_only_once()
 
         # Mocked out init for Hass class.
         # It needs to be in this scope so it can get access to variables used here like `_hass_instances`

--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -1,12 +1,32 @@
 import logging
 import mock
 from appdaemon.plugins.hass.hassapi import Hass
+import appdaemon.utils
+from packaging import version
 import textwrap
 import warnings
 
 
+class _DeprecatedAppdaemonWarning:
+    # Use class vars so we can keep sticky state to only warn once per test session
+    already_warned_deprecated_appdaemon_version = False
+    min_supported_version = version.Version('4.0.0')
+
+    def __init__(self):
+        if self.already_warned_deprecated_appdaemon_version:
+            return
+        self.already_warned_deprecated_appdaemon_version = True
+
+        appdaemon_version = version.Version(appdaemon.utils.__version__)
+        if appdaemon_version < self.min_supported_version :
+            warnings.warn("Appdaemon-Test-Framework will only support Appdaemon >={} in the next major release. Your current Appdemon version is {}"
+                            .format(self.min_supported_version, appdaemon_version), DeprecationWarning)
+
+
 class HassMocks:
     def __init__(self):
+        _DeprecatedAppdaemonWarning()
+
         # Mocked out init for Hass class.
         # It needs to be in this scope so it can get access to variables used here like `_hass_instances`
         _hass_instances = [] # use a local variable so we can access it below in `_hass_init_mock`

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ setup(
     packages=['appdaemontestframework'],
     license='MIT',
     install_requires=[
-        'appdaemon',
-        'mock'
+        'appdaemon>=4.0,<5.0',
+        'mock>=3.0.5,<4.0',
+        'packaging>=20.1,<21.0',
     ],
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['appdaemontestframework'],
     license='MIT',
     install_requires=[
-        'appdaemon>=4.0,<5.0',
+        'appdaemon>=3.0,<5.0',
         'mock>=3.0.5,<4.0',
         'packaging>=20.1,<21.0',
     ],


### PR DESCRIPTION
This PR fixes #32 by adding a deprecation warning if run with appdaemon <4.0. It will report this warning only up to once per a test as follows:
```
test/integration_tests/tests/test_kitchen.py::TestClickCancellation::TestMixedClicks::test_long_then_short_keep_latest[Kitchen]
  /home/mcampbell/personal/lifeisafractal_github/Appdaemon-Test-Framework/appdaemontestframework/hass_mocks.py:23: DeprecationWarning: Appdaemon-Test-Framework will only support Appdaemon >=4.0.0 in the next major release. Your current Appdemon version is 3.0.5
    .format(self.min_supported_version, appdaemon_version), DeprecationWarning)
```

This PR also adds version constraints to the `setup.py`. I'm not familiar with using a `Pipfile` and `Pipfile.lock`, but I'm wondering  if we should be using one or the other of these methods to constrain packages. Can you weigh in on that one?

## Testing done locally
* All tests pass using `tox`
* I manually downgraded Appdaemon to 3.0.5 and confined I get the above deprecation warnings.