### PR TITLE
fix deprecated code usage

### DIFF
--- a/test/integration_tests/tests/test_bathroom.py
+++ b/test/integration_tests/tests/test_bathroom.py
@@ -74,11 +74,11 @@ class TestInitialize:
         bathroom.initialize()
         assert_evening_mode_started()
 
-    def test_callbacks_are_registered(self, bathroom, hass_functions):
+    def test_callbacks_are_registered(self, bathroom, hass_mocks):
         # Given: The mocked callback Appdaemon registration functions
-        listen_event = hass_functions['listen_event']
-        listen_state = hass_functions['listen_state']
-        run_daily = hass_functions['run_daily']
+        listen_event = hass_mocks.hass_functions['listen_event']
+        listen_state = hass_mocks.hass_functions['listen_state']
+        run_daily = hass_mocks.hass_functions['run_daily']
 
         # When: Calling `initialize`
         bathroom.initialize()

--- a/test/integration_tests/tests/test_kitchen.py
+++ b/test/integration_tests/tests/test_kitchen.py
@@ -35,10 +35,10 @@ def when_new(kitchen):
 
 
 class TestInitialization:
-    def test_callbacks_are_registered(self, kitchen, hass_functions):
+    def test_callbacks_are_registered(self, kitchen, hass_mocks):
         # Given: The mocked callback Appdaemon registration functions
-        listen_event = hass_functions['listen_event']
-        listen_state = hass_functions['listen_state']
+        listen_event = hass_mocks.hass_functions['listen_event']
+        listen_state = hass_mocks.hass_functions['listen_state']
 
         # When: Calling `initialize`
         kitchen.initialize()


### PR DESCRIPTION
This is a follow on to PR #27 which introduced `hass_mocks` and deprecates direct use of `hass_functions`. This PR fixes up all the included examples to no longer use deprecated interfaces.