### PR TITLE
Only release tagged commits from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ jobs:
           secure: yGP3vlxjwuJypHkuaCUBdXxjuZNUwJb/NGyTruIqnaNqNK/R2Q6Z+ICUsBxzhGUNJNWfyYTOHt/BLPHOIyt0/jAGL0JsFLRpQlT+HmwbjzQi/TFF48b1EiP36ivXszrY/aCjw3/yiqcHWxkOzpf93ximt0KEDNVg94g5vqQS7IwDZw39pZsfbrNTX+ycBTcU5D0juv1JXGge0X4upBLBUaPC8HZD5uE/EhiPjjQkI9ti4W1Z4fdk+etpYTWIW8txL/IeNr2eVfQJjl1BSvrlI1eGFVuyj6WqiOmodNjZrQqKUw/MbcvsvnyR2PLy/krsCC7pnArGt61HQuVXRRCWT3iGcVp9/OgKCN7UGOAJJmyYOOp8QfEuG6ft3PFbcs72y4qi7AA+r/B0QFHRvsx1MyueoRVCkQaqXY2WL6O7ZkgaDzCvvAHqKtMvR6qjzGMi7huDqyhUEm90tZ04VvnBwYqFrvbYUCtkmpIAAmy5o5CXHm7wetO19SL+Vpw92+5QWDfoZgr95YJ5ayqkPz3VxIn6Tj+yR76PNfpI4QT8XFPtcb5iVRCTCi1c/RmvO17FupBhPhHlUV1HUkWQQHuS+i/LuAB1Bgk0wdXhN1IsJMcg90vO/Zq+oUYMNaNRJwxONugKnBv0L1tov6CcgkoqeHjDCifDl9YkzwSx+8YDlxo=
         on:
           tags: true
+          branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ jobs:
           secure: yGP3vlxjwuJypHkuaCUBdXxjuZNUwJb/NGyTruIqnaNqNK/R2Q6Z+ICUsBxzhGUNJNWfyYTOHt/BLPHOIyt0/jAGL0JsFLRpQlT+HmwbjzQi/TFF48b1EiP36ivXszrY/aCjw3/yiqcHWxkOzpf93ximt0KEDNVg94g5vqQS7IwDZw39pZsfbrNTX+ycBTcU5D0juv1JXGge0X4upBLBUaPC8HZD5uE/EhiPjjQkI9ti4W1Z4fdk+etpYTWIW8txL/IeNr2eVfQJjl1BSvrlI1eGFVuyj6WqiOmodNjZrQqKUw/MbcvsvnyR2PLy/krsCC7pnArGt61HQuVXRRCWT3iGcVp9/OgKCN7UGOAJJmyYOOp8QfEuG6ft3PFbcs72y4qi7AA+r/B0QFHRvsx1MyueoRVCkQaqXY2WL6O7ZkgaDzCvvAHqKtMvR6qjzGMi7huDqyhUEm90tZ04VvnBwYqFrvbYUCtkmpIAAmy5o5CXHm7wetO19SL+Vpw92+5QWDfoZgr95YJ5ayqkPz3VxIn6Tj+yR76PNfpI4QT8XFPtcb5iVRCTCi1c/RmvO17FupBhPhHlUV1HUkWQQHuS+i/LuAB1Bgk0wdXhN1IsJMcg90vO/Zq+oUYMNaNRJwxONugKnBv0L1tov6CcgkoqeHjDCifDl9YkzwSx+8YDlxo=
         on:
           tags: true
-          branch: master
+          condition: $TRAVIS_BRANCH =~ ^(master)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * None
 
 
+# [3.0.1] 2020-03-03
+Minor release to test CD pipeline
+
+
 # [3.0.0] 2020-03-03
 ## Features
 * None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * None
 
 
-# [3.0.1] 2020-03-03
-Minor release to test CD pipeline
+# [3.0.1-2] 2020-03-03
+Minor releases to test CD pipeline
 
 
 # [3.0.0] 2020-03-03

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='appdaemontestframework',
-    version='3.0.0',
+    version='3.0.1',
     description='Clean, human-readable tests for Appdaemon',
     long_description='See: https://floriankempenich.github.io/Appdaemon-Test-Framework/',
     keywords='appdaemon homeassistant test tdd clean-code home-automation',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='appdaemontestframework',
-    version='3.0.1',
+    version='3.0.2',
     description='Clean, human-readable tests for Appdaemon',
     long_description='See: https://floriankempenich.github.io/Appdaemon-Test-Framework/',
     keywords='appdaemon homeassistant test tdd clean-code home-automation',


### PR DESCRIPTION
Update Travis config to ensure tagged commits on a branch different than `master` aren't released automatically.

This allows to prepare a release in a PR, and once merge it will automatically be released to PyPI.

**From now on, to enable automatic release on merge:**
1. Do the PR-related changes
1. Update `CHANGELOG`
1. Bump version in `setup.py`, ie `4.2.6`
1. Create a commit `Release 4.2.6`
1. Tag the commit `git tag v4.2.6`
1. Done. When merging the PR, the new version will be automatically released, but not before 😁