### PR TITLE
Automation can now fire events without crashing the test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 *
 
 ## Fixes
-*
+* Automations can fire events without crashing the test framework
 
 ## Breaking Changes
 * None

--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -93,6 +93,7 @@ class HassMocks:
             MockHandler(Hass, 'call_service'),
             MockHandler(Hass, 'turn_on'),
             MockHandler(Hass, 'turn_off'),
+            MockHandler(Hass, 'fire_event'),
 
             ### Custom callback functions
             MockHandler(Hass, 'register_constraint'),

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,0 +1,27 @@
+from appdaemon.plugins.hass.hassapi import Hass
+
+from appdaemontestframework import automation_fixture
+
+LIGHT = 'light.some_light'
+COVER = 'cover.some_cover'
+
+
+class MockAutomation(Hass):
+    def initialize(self):
+        pass
+
+    def send_event(self):
+        self.fire_event("SOME_EVENT", my_keyword="hello")
+
+
+@automation_fixture(MockAutomation)
+def automation():
+    pass
+
+
+def test_it_does_not_crash_when_testing_automation_that_sends_events(given_that,
+                                                                     automation: MockAutomation):
+    # For now, there is not assertion feature on events, so we're just ensuring
+    # appdaemontestframework is not crashing when testing an automation that
+    # sends events.
+    automation.send_event()


### PR DESCRIPTION
This fixes #41 