### PR TITLE
Added AppDaemon command.

### DIFF
--- a/appdaemontestframework/hass_mocks.py
+++ b/appdaemontestframework/hass_mocks.py
@@ -94,6 +94,7 @@ class HassMocks:
             MockHandler(Hass, 'turn_on'),
             MockHandler(Hass, 'turn_off'),
             MockHandler(Hass, 'fire_event'),
+            MockHandler(Hass, 'select_option'),
 
             ### Custom callback functions
             MockHandler(Hass, 'register_constraint'),


### PR DESCRIPTION
select_option is a AppDaemon command that was not mocked.

in issue #48 I used the select_option AppDaemon method. It seems that it was not implemented. Adding it to the list of the mocked function allowed me to make my tests work. 

I don't know if this change is the only needed, in the case, can I be instructed on other changes to do?