### PR TITLE
Package source folder including sub-directories (packages)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='appdaemontestframework',
-    version='4.0.0b0',
+    version='4.0.0b1',
     description='Clean, human-readable tests for Appdaemon',
     long_description='See: https://floriankempenich.github.io/Appdaemon-Test-Framework/',
     keywords='appdaemon homeassistant test tdd clean-code home-automation',
@@ -18,7 +18,7 @@ setup(
     url='https://floriankempenich.github.io/Appdaemon-Test-Framework',
     author='Florian Kempenich',
     author_email='Flori@nKempenich.com',
-    packages=['appdaemontestframework'],
+    packages=find_packages(include='appdaemontestframework*'),
     license='MIT',
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
This is a fix, inspired by the detailed report from #51 , that also fixes #55.

Tests:
automated tests not applicable, as it was a bug relating only to the setup.py file, which had to be changed now that we have a subdirectory (sub-package?) in the appdaemontestframework directory.

I did of course test with the test case I had constructed in #55, by installing the wheel I created using this new setup.py file and the test then succeeded and failed as expected when changing the "automation".

So I confirmed this works.
