### PR TITLE
Add service name validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Appdaemon Test Framework
-[![Build Status](https://www.travis-ci.com/FlorianKempenich/Appdaemon-Test-Framework.svg?branch=master)](https://travis-ci.com/github/FlorianKempenich/Appdaemon-Test-Framework) [![PyPI](https://img.shields.io/pypi/v/appdaemontestframework.svg)](https://pypi.org/project/appdaemontestframework/)
+[![Build Status](https://www.travis-ci.com/FlorianKempenich/Appdaemon-Test-Framework.svg?branch=master)](https://travis-ci.com/github/FlorianKempenich/Appdaemon-Test-Framework) [![PyPI](https://img.shields.io/pypi/v/appdaemontestframework.svg)](https://pypi.org/project/appdaemontestframework/) [![Python 3.7](https://img.shields.io/badge/appdaemon-4.x-blue.svg)](TODO) [![Python 3.6](https://img.shields.io/badge/python-3.7-yellow.svg)](https://www.python.org/downloads/release/python-370/) [![Python 3.8](https://img.shields.io/badge/python-3.8-yellow.svg)](https://www.python.org/downloads/release/python-380/)
 
 Clean, human-readable tests for your Appdaemon automations.
 

--- a/test/test_assert_that.py
+++ b/test/test_assert_that.py
@@ -1,8 +1,5 @@
-from datetime import time, datetime
-
 import appdaemon.plugins.hass.hassapi as hass
 import pytest
-from pytest import mark
 
 from appdaemontestframework import automation_fixture
 
@@ -73,6 +70,12 @@ class MockAutomation(hass.Hass):
                 transition=TRANSITION_DURATION
             )
 
+    def call_invalid_service_name(self):
+        self.call_service(
+            'switch.turn_off',
+            entity_id=SWITCH
+        )
+
 
 @automation_fixture(MockAutomation)
 def automation():
@@ -141,3 +144,23 @@ class TestTurnedOff:
             assert_that(LIGHT).was_not.turned_off()
             automation.turn_off_light_with_transition(via_helper=True)
             assert_that(LIGHT).was.turned_off(transition=TRANSITION_DURATION)
+
+
+class TestServiceNameValidation:
+    class TestValidServiceName:
+        def test_valid_service_asserted_and_is_called_does_not_raise(self, assert_that, automation):
+            automation.turn_off_switch(via_helper=False)
+            assert_that('switch/turn_off') \
+                .was.called_with(entity_id=SWITCH)
+
+        def test_valid_service_asserted_and_is_not_called_raises_assertion_error(self, assert_that, automation):
+            automation.turn_off_switch(via_helper=False)
+            assert_that('switch/turn_off') \
+                .was.called_with(entity_id=SWITCH)
+
+    class TestInvalidServiceName:
+        def test_invalid_service_asserted_and_is_called_raises_value_error(self, assert_that, automation):
+            automation.call_invalid_service_name()
+            with pytest.raises(ValueError):
+                assert_that('switch.turn_off')\
+                    .was.called_with(entity_id=SWITCH)


### PR DESCRIPTION
Implements #59.
I just couldn't wait.

I do have doubts about one "missing" test case. What if the service name is invalid (that would cause a ValueError) and it has not been called (that would raise AssertionError).

I think I am fine with any of them being called, or both.